### PR TITLE
Added disabled-by-default ports to config

### DIFF
--- a/c_sharp_for_home_assistant/config.json
+++ b/c_sharp_for_home_assistant/config.json
@@ -14,7 +14,17 @@
   "options": {},
   "schema": {},
   "ports": {
-    "20777/tcp": 20777
+    "20777/tcp": 20777,
+    "10000/udp": null,
+    "10001/udp": null,
+    "10002/udp": null,
+    "10003/udp": null,
+    "10004/udp": null,
+    "20000/tcp": null,
+    "20001/tcp": null,
+    "20002/tcp": null,
+    "20003/tcp": null,
+    "20004/tcp": null
   },
   "map": ["config:rw"],
   "image": "limeray/c-sharp-for-homeassistant"


### PR DESCRIPTION
- Added 5 UDP ports starting at 10,000
- Added 5 TCP ports starting at 20,000

- These will be disabled by default and only will be enabled by the end user in config tab in add-on in home assistant

- End user can easily map to any outside port