### PR TITLE
Update IsAway string to newer HA version

### DIFF
--- a/c_sharp_for_home_assistant/src/hhnl.HomeAssistantNet/hhnl.HomeAssistantNet.Shared/Entities/HomeAwayEntity.cs
+++ b/c_sharp_for_home_assistant/src/hhnl.HomeAssistantNet/hhnl.HomeAssistantNet.Shared/Entities/HomeAwayEntity.cs
@@ -10,6 +10,6 @@ namespace hhnl.HomeAssistantNet.Shared.Entities
 
         public bool IsHome => base.State == "home";
         
-        public bool IsAway => base.State == "away";
+        public bool IsAway => base.State == "not_home";
     }
 }


### PR DESCRIPTION
The "IsAway" string in newer HA versions changed from "away" to "not_home".